### PR TITLE
fix : Record 생성 시 None 케이스 추가 및 Operate 리턴형 변경

### DIFF
--- a/AceAgent/RecordMaker.cpp
+++ b/AceAgent/RecordMaker.cpp
@@ -5,9 +5,17 @@ vector<string> careerLevelName = { "CL1", "CL2", "CL3", "CL4" };
 vector<string> certiLevelName = { "ADV", "PRO", "EX" };
 
 vector<string>
-RecordMaker::makeRecord(bool isDetailPrint, int searchCnt, Command cmdType, vector<EmployeeInformation> employeeInfoList)
+RecordMaker::makeRecord(bool isDetailPrint, Command cmdType, vector<EmployeeInformation> employeeInfoList)
 {
     vector<string> result;
+
+    if (employeeInfoList.size() == 0)
+    {
+        string record = cmdTypeName[(int)cmdType] + ",NONE";
+        result.push_back(record);
+
+        return result;
+    }
 
     if (isDetailPrint)
     {
@@ -42,7 +50,7 @@ RecordMaker::makeRecord(bool isDetailPrint, int searchCnt, Command cmdType, vect
     }
     else
     {
-        string record = cmdTypeName[(int)cmdType] + "," + to_string(searchCnt);
+        string record = cmdTypeName[(int)cmdType] + "," + to_string(employeeInfoList.size());
         result.push_back(record);
     }
 

--- a/AceAgent/RecordMaker.h
+++ b/AceAgent/RecordMaker.h
@@ -8,5 +8,5 @@
 class RecordMaker
 {
 public:
-    vector<string> makeRecord(bool isDetailPrint, int searchCnt, Command cmdType, vector<EmployeeInformation> employeeInfoList);
+    vector<string> makeRecord(bool isDetailPrint, Command cmdType, vector<EmployeeInformation> employeeInfoList);
 };

--- a/AceAgent/operator.cpp
+++ b/AceAgent/operator.cpp
@@ -33,14 +33,14 @@ Operator::addEmployee(EmployeeInformation employeeInfo)
     insertData(employeeInfo);
 }
 
-ProcessResult*
-Operator::delEmployee(bool isDetailPrint, SelectType SelectType, EmployeeInformation employeeInfo)
+ProcessResult
+Operator::delEmployee(bool isDetailPrint, SelectType selectType, EmployeeInformation employeeInfo)
 {
     string record;
     ProcessResult result;
     vector<EmployeeInformation> list;
     
-    if (SelectType == SelectType::EMPLOYEE_NUMBER && employeeInfo.employeeNumber_ < EMPLOYEE_NUM_BOUND)
+    if (selectType == SelectType::EMPLOYEE_NUMBER && employeeInfo.employeeNumber_ < EMPLOYEE_NUM_BOUND)
     {
         employeeInfo.employeeNumber_ += EMPLOYEE_NUM_CORRECTION;
     }
@@ -49,31 +49,27 @@ Operator::delEmployee(bool isDetailPrint, SelectType SelectType, EmployeeInforma
 
     result.numOfRecord = list.size();
 
-    if (list.size() == 0)
+    if (list.size() != 0)
     {
-        result.printRecord.clear();
-
-        return &result;
+        for (auto it : list)
+        {
+            deleteData(it);
+        }
     }
 
-    for (auto it : list)
-    {
-        deleteData(it);
-    }
+    result.printRecord = pRecordMaker->makeRecord(isDetailPrint, Command::DEL, list);
 
-    result.printRecord = pRecordMaker->makeRecord(isDetailPrint, list.size(), Command::DEL, list);
-
-    return &result;
+    return result;
 }
 
-ProcessResult*
-Operator::schEmployee(bool isDetailPrint, SelectType SelectType, EmployeeInformation employeeInfo)
+ProcessResult
+Operator::schEmployee(bool isDetailPrint, SelectType selectType, EmployeeInformation employeeInfo)
 {
     string record;
     ProcessResult result;
     vector<EmployeeInformation> list;
 
-    if (SelectType == SelectType::EMPLOYEE_NUMBER && employeeInfo.employeeNumber_ < EMPLOYEE_NUM_BOUND)
+    if (selectType == SelectType::EMPLOYEE_NUMBER && employeeInfo.employeeNumber_ < EMPLOYEE_NUM_BOUND)
     {
         employeeInfo.employeeNumber_ += EMPLOYEE_NUM_CORRECTION;
     }
@@ -82,20 +78,13 @@ Operator::schEmployee(bool isDetailPrint, SelectType SelectType, EmployeeInforma
 
     result.numOfRecord = list.size();
 
-    if (list.size() == 0)
-    {
-        result.printRecord.clear();
+    result.printRecord = pRecordMaker->makeRecord(isDetailPrint, Command::DEL, list);
 
-        return &result;
-    }
-
-    result.printRecord = pRecordMaker->makeRecord(isDetailPrint, list.size(), Command::DEL, list);
-
-    return &result;
+    return result;
 
 }
 
-ProcessResult*
+ProcessResult
 Operator::modEmployee(bool isDetailPrint, SelectType selectType, EmployeeInformation employeeInfo, SelectType modOption, EmployeeInformation modEmployeeInfo)
 {
     Operator* pOperator = new Operator;
@@ -111,19 +100,17 @@ Operator::modEmployee(bool isDetailPrint, SelectType selectType, EmployeeInforma
 
     result.numOfRecord = list.size();
 
-    if (list.size() == 0)
+    if (list.size() != 0)
     {
-        return &result;
+        for (auto it : list)
+        {
+            pOperator->_modData(pDataManager, modOption, it.employeeNumber_, modEmployeeInfo);
+        }
     }
 
-    for (auto it : list)
-    {
-        pOperator->_modData(pDataManager, modOption, it.employeeNumber_, modEmployeeInfo);
-    }
+    result.printRecord = pRecordMaker->makeRecord(isDetailPrint, Command::MOD, list);
 
-    result.printRecord = pRecordMaker->makeRecord(isDetailPrint, list.size(), Command::MOD, list);
-
-    return &result;
+    return result;
 }
 
 void

--- a/AceAgent/operator.h
+++ b/AceAgent/operator.h
@@ -30,10 +30,9 @@ public:
     RecordMaker* getRecordMaker() { return pRecordMaker; }
 
     void addEmployee(EmployeeInformation employeeInfo);
-
-    ProcessResult* delEmployee(bool isDetailPrint, SelectType selectType, EmployeeInformation employeeInfo);
-    ProcessResult* schEmployee(bool isDetailPrint, SelectType selectType, EmployeeInformation employeeInfo);
-    ProcessResult* modEmployee(bool isDetailPrint, SelectType selectType, EmployeeInformation employeeInfo, SelectType modOption, EmployeeInformation modEmployeeInfo);
+    ProcessResult delEmployee(bool isDetailPrint, SelectType selectType, EmployeeInformation employeeInfo);
+    ProcessResult schEmployee(bool isDetailPrint, SelectType selectType, EmployeeInformation employeeInfo);
+    ProcessResult modEmployee(bool isDetailPrint, SelectType selectType, EmployeeInformation employeeInfo, SelectType modOption, EmployeeInformation modEmployeeInfo);
     void _modData(DataManager* pDataManager, SelectType modOption, unsigned int employeeNumber, EmployeeInformation modEmployeeInfo);
 
     void insertData(EmployeeInformation employeeInfo);

--- a/UnitTest/Operator_Test.cpp
+++ b/UnitTest/Operator_Test.cpp
@@ -57,13 +57,17 @@ TEST_F(OperatorTest, delOperatorTestbyName) {
 
     EmployeeInformation* pEmployeeInfo = new EmployeeInformation(18115040, "TTETHU", "HBO", CareerLevel::CL3, 4581, 2050, 2008, 07, 18, CertiLevel::ADV);
 
-    ProcessResult* pResult = pOperator->delEmployee(true, SelectType::FULL_NAME, *pEmployeeInfo);
-    EXPECT_EQ(pResult->numOfRecord, 1);
+    ProcessResult result = pOperator->delEmployee(true, SelectType::FULL_NAME, *pEmployeeInfo);
+    EXPECT_EQ(result.numOfRecord, 1);
 
     pEmployeeInfo->name_.first = "ABC";
     pEmployeeInfo->name_.last = "DEF";
-    pResult = pOperator->delEmployee(false, SelectType::FULL_NAME, *pEmployeeInfo);
-    EXPECT_EQ(pResult->numOfRecord, 0);
+    result = pOperator->delEmployee(false, SelectType::FULL_NAME, *pEmployeeInfo);
+    EXPECT_EQ(result.numOfRecord, 0);
+    for (auto it : result.printRecord)
+    {
+        cout << it << endl;
+    }
 
     map<unsigned int, EmployeeInformation> list = pOperator->getDataManager()->getEmployeeMap();
 
@@ -86,8 +90,12 @@ TEST_F(OperatorTest, delOperatorTestbyFirstName) {
 
     EmployeeInformation* pEmployeeInfo = new EmployeeInformation(15123099, "VXIHXOTH", "JHOP", CareerLevel::CL3, 3112, 2609, 1977, 12, 11, CertiLevel::ADV);
 
-    ProcessResult* pResult = pOperator->delEmployee(false, SelectType::FIRST_NAME, *pEmployeeInfo);
-    EXPECT_EQ(pResult->numOfRecord, 1);
+    ProcessResult result = pOperator->delEmployee(true, SelectType::FIRST_NAME, *pEmployeeInfo);
+    EXPECT_EQ(result.numOfRecord, 1);
+    for (auto it : result.printRecord)
+    {
+        cout << it << endl;
+    }
 
     map<unsigned int, EmployeeInformation> list = pOperator->getDataManager()->getEmployeeMap();
 
@@ -110,8 +118,12 @@ TEST_F(OperatorTest, delOperatorTestbyLastName) {
 
     EmployeeInformation* pEmployeeInfo = new EmployeeInformation(88114052, "NQ", "LVARW", CareerLevel::CL4, 4528, 3059, 1991, 10, 21, CertiLevel::PRO);
 
-    ProcessResult* pResult = pOperator->delEmployee(false, SelectType::LAST_NAME, *pEmployeeInfo);
-    EXPECT_EQ(pResult->numOfRecord, 1);
+    ProcessResult result = pOperator->delEmployee(true, SelectType::LAST_NAME, *pEmployeeInfo);
+    EXPECT_EQ(result.numOfRecord, 1);
+    for (auto it : result.printRecord)
+    {
+        cout << it << endl;
+    }
 
     map<unsigned int, EmployeeInformation> list = pOperator->getDataManager()->getEmployeeMap();
 
@@ -134,8 +146,12 @@ TEST_F(OperatorTest, delOperatorTestbyCl) {
 
     EmployeeInformation* pEmployeeInfo = new EmployeeInformation(88114052, "NQ", "LVARW", CareerLevel::CL4, 4528, 3059, 1991, 10, 21, CertiLevel::PRO);
 
-    ProcessResult* pResult = pOperator->delEmployee(false, SelectType::CAREER_LEVEL, *pEmployeeInfo);
-    EXPECT_EQ(pResult->numOfRecord, 4);
+    ProcessResult result = pOperator->delEmployee(true, SelectType::CAREER_LEVEL, *pEmployeeInfo);
+    EXPECT_EQ(result.numOfRecord, 4);
+    for (auto it : result.printRecord)
+    {
+        cout << it << endl;
+    }
 
     map<unsigned int, EmployeeInformation> list = pOperator->getDataManager()->getEmployeeMap();
 
@@ -158,8 +174,12 @@ TEST_F(OperatorTest, delOperatorTestbyPhoneNum) {
 
     EmployeeInformation* pEmployeeInfo = new EmployeeInformation(88114052, "NQ", "LVARW", CareerLevel::CL4, 4528, 3059, 1991, 10, 21, CertiLevel::PRO);
 
-    ProcessResult* pResult = pOperator->delEmployee(false, SelectType::FULL_PHONE_NUMBER, *pEmployeeInfo);
-    EXPECT_EQ(pResult->numOfRecord, 1);
+    ProcessResult result = pOperator->delEmployee(true, SelectType::FULL_PHONE_NUMBER, *pEmployeeInfo);
+    EXPECT_EQ(result.numOfRecord, 1);
+    for (auto it : result.printRecord)
+    {
+        cout << it << endl;
+    }
 
     map<unsigned int, EmployeeInformation> list = pOperator->getDataManager()->getEmployeeMap();
 
@@ -182,8 +202,12 @@ TEST_F(OperatorTest, delOperatorTestbyMidPhoneNum) {
 
     EmployeeInformation* pEmployeeInfo = new EmployeeInformation(88114052, "NQ", "LVARW", CareerLevel::CL4, 4528, 3059, 1991, 10, 21, CertiLevel::PRO);
 
-    ProcessResult* pResult = pOperator->delEmployee(false, SelectType::MID_PHONE_NUMBER, *pEmployeeInfo);
-    EXPECT_EQ(pResult->numOfRecord, 1);
+    ProcessResult result = pOperator->delEmployee(true, SelectType::MID_PHONE_NUMBER, *pEmployeeInfo);
+    EXPECT_EQ(result.numOfRecord, 1);
+    for (auto it : result.printRecord)
+    {
+        cout << it << endl;
+    }
 
     map<unsigned int, EmployeeInformation> list = pOperator->getDataManager()->getEmployeeMap();
 
@@ -206,8 +230,12 @@ TEST_F(OperatorTest, delOperatorTestbyLastPhoneNum) {
 
     EmployeeInformation* pEmployeeInfo = new EmployeeInformation(17112609, "FB", "NTAWR", CareerLevel::CL4, 5645, 6122, 1986, 12, 03, CertiLevel::PRO);
 
-    ProcessResult* pResult = pOperator->delEmployee(false, SelectType::LAST_PHONE_NUMBER, *pEmployeeInfo);
-    EXPECT_EQ(pResult->numOfRecord, 1);
+    ProcessResult result = pOperator->delEmployee(true, SelectType::LAST_PHONE_NUMBER, *pEmployeeInfo);
+    EXPECT_EQ(result.numOfRecord, 1);
+    for (auto it : result.printRecord)
+    {
+        cout << it << endl;
+    }
 
     map<unsigned int, EmployeeInformation> list = pOperator->getDataManager()->getEmployeeMap();
 
@@ -230,8 +258,12 @@ TEST_F(OperatorTest, delOperatorTestbyBirthday) {
 
     EmployeeInformation* pEmployeeInfo = new EmployeeInformation(19129568, "SRERLALH", "HMEF", CareerLevel::CL2, 3091, 9521, 1964, 9, 10, CertiLevel::PRO);
 
-    ProcessResult* pResult = pOperator->delEmployee(false, SelectType::FULL_BIRTHDAY, *pEmployeeInfo);
-    EXPECT_EQ(pResult->numOfRecord, 1);
+    ProcessResult result = pOperator->delEmployee(true, SelectType::FULL_BIRTHDAY, *pEmployeeInfo);
+    EXPECT_EQ(result.numOfRecord, 1);
+    for (auto it : result.printRecord)
+    {
+        cout << it << endl;
+    }
 
     map<unsigned int, EmployeeInformation> list = pOperator->getDataManager()->getEmployeeMap();
 
@@ -254,8 +286,12 @@ TEST_F(OperatorTest, delOperatorTestbyYearOfBirthday) {
 
     EmployeeInformation* pEmployeeInfo = new EmployeeInformation(17112609, "FB", "NTAWR", CareerLevel::CL4, 5645, 6122, 1986, 12, 03, CertiLevel::PRO);
 
-    ProcessResult* pResult = pOperator->delEmployee(false, SelectType::YEAR_OF_BIRTHDAY, *pEmployeeInfo);
-    EXPECT_EQ(pResult->numOfRecord, 1);
+    ProcessResult result = pOperator->delEmployee(true, SelectType::YEAR_OF_BIRTHDAY, *pEmployeeInfo);
+    EXPECT_EQ(result.numOfRecord, 1);
+    for (auto it : result.printRecord)
+    {
+        cout << it << endl;
+    }
 
     map<unsigned int, EmployeeInformation> list = pOperator->getDataManager()->getEmployeeMap();
 
@@ -278,8 +314,12 @@ TEST_F(OperatorTest, delOperatorTestbyMonthOfBirthday) {
 
     EmployeeInformation* pEmployeeInfo = new EmployeeInformation(17112609, "FB", "NTAWR", CareerLevel::CL4, 5645, 6122, 1986, 12, 03, CertiLevel::PRO);
 
-    ProcessResult* pResult = pOperator ->delEmployee(false, SelectType::MONTH_OF_BIRTHDAY, *pEmployeeInfo);
-    EXPECT_EQ(pResult->numOfRecord, 2);
+    ProcessResult result = pOperator ->delEmployee(true, SelectType::MONTH_OF_BIRTHDAY, *pEmployeeInfo);
+    EXPECT_EQ(result.numOfRecord, 2);
+    for (auto it : result.printRecord)
+    {
+        cout << it << endl;
+    }
 
     map<unsigned int, EmployeeInformation> list = pOperator->getDataManager()->getEmployeeMap();
 
@@ -302,8 +342,12 @@ TEST_F(OperatorTest, delOperatorTestbyDayOfBirthday) {
 
     EmployeeInformation* pEmployeeInfo = new EmployeeInformation(88114052, "NQ", "LVARW", CareerLevel::CL4, 4528, 3059, 1991, 10, 21, CertiLevel::PRO);
 
-    ProcessResult* pResult = pOperator->delEmployee(false, SelectType::DAY_OF_BIRTHDAY, *pEmployeeInfo);
-    EXPECT_EQ(pResult->numOfRecord, 1);
+    ProcessResult result = pOperator->delEmployee(true, SelectType::DAY_OF_BIRTHDAY, *pEmployeeInfo);
+    EXPECT_EQ(result.numOfRecord, 1);
+    for (auto it : result.printRecord)
+    {
+        cout << it << endl;
+    }
 
     map<unsigned int, EmployeeInformation> list = pOperator->getDataManager()->getEmployeeMap();
 
@@ -326,7 +370,11 @@ TEST_F(OperatorTest, delOperatorTestbyCertiLevel) {
 
     EmployeeInformation* pEmployeeInfo = new EmployeeInformation(88114052, "NQ", "LVARW", CareerLevel::CL4, 4528, 3059, 1991, 10, 21, CertiLevel::PRO);
 
-    ProcessResult* pResult = pOperator->delEmployee(false, SelectType::CERTI_LEVEL, *pEmployeeInfo);
+    ProcessResult result = pOperator->delEmployee(true, SelectType::CERTI_LEVEL, *pEmployeeInfo);
+    for (auto it : result.printRecord)
+    {
+        cout << it << endl;
+    }
 
     map<unsigned int, EmployeeInformation> list = pOperator->getDataManager()->getEmployeeMap();
 
@@ -349,14 +397,22 @@ TEST_F(OperatorTest, schOperatorTestbyName) {
 
     EmployeeInformation* pEmployeeInfo = new EmployeeInformation(8123556, "WN", "XV", CareerLevel::CL1, 7986, 5047, 2010, 06, 14, CertiLevel::PRO);
 
-    ProcessResult* pResult = pOperator->schEmployee(false, SelectType::FULL_NAME, *pEmployeeInfo);
-    EXPECT_EQ(pResult->numOfRecord, 1);
+    ProcessResult result = pOperator->schEmployee(true, SelectType::FULL_NAME, *pEmployeeInfo);
+    EXPECT_EQ(result.numOfRecord, 1);
+    for (auto it : result.printRecord)
+    {
+        cout << it << endl;
+    }
 
     pEmployeeInfo->name_.first = "VCUHLE";
     pEmployeeInfo->name_.last = "HMU";
 
-    pResult = pOperator->schEmployee(false, SelectType::FULL_NAME, *pEmployeeInfo);
-    EXPECT_EQ(pResult->numOfRecord, 0);
+    result = pOperator->schEmployee(false, SelectType::FULL_NAME, *pEmployeeInfo);
+    EXPECT_EQ(result.numOfRecord, 0);
+    for (auto it : result.printRecord)
+    {
+        cout << it << endl;
+    }
 
     delete pEmployeeInfo;
 }
@@ -366,13 +422,21 @@ TEST_F(OperatorTest, schOperatorTestbyFirstName) {
 
     EmployeeInformation* pEmployeeInfo = new EmployeeInformation(2117175, "SBILHUT", "LDEXRI", CareerLevel::CL4, 2814, 1699, 1995, 07, 04, CertiLevel::ADV);
 
-    ProcessResult* pResult = pOperator->schEmployee(false, SelectType::FIRST_NAME, *pEmployeeInfo);
-    EXPECT_EQ(pResult->numOfRecord, 1);
+    ProcessResult result = pOperator->schEmployee(true, SelectType::FIRST_NAME, *pEmployeeInfo);
+    EXPECT_EQ(result.numOfRecord, 1);
+    for (auto it : result.printRecord)
+    {
+        cout << it << endl;
+    }
 
     pEmployeeInfo->name_.first = "VCUHLE";
 
-    pResult = pOperator->schEmployee(false, SelectType::FIRST_NAME, *pEmployeeInfo);
-    EXPECT_EQ(pResult->numOfRecord, 0);
+    result = pOperator->schEmployee(false, SelectType::FIRST_NAME, *pEmployeeInfo);
+    EXPECT_EQ(result.numOfRecord, 0);
+    for (auto it : result.printRecord)
+    {
+        cout << it << endl;
+    }
 
     delete pEmployeeInfo;
 }
@@ -382,13 +446,21 @@ TEST_F(OperatorTest, schOperatorTestbyLastName) {
 
     EmployeeInformation* pEmployeeInfo = new EmployeeInformation(19129568, "SRERLALH", "HMEF", CareerLevel::CL2, 3091, 9521, 1964, 9, 10, CertiLevel::PRO);
 
-    ProcessResult* pResult = pOperator->schEmployee(false, SelectType::LAST_NAME, *pEmployeeInfo);
-    EXPECT_EQ(pResult->numOfRecord, 1);
+    ProcessResult result = pOperator->schEmployee(true, SelectType::LAST_NAME, *pEmployeeInfo);
+    EXPECT_EQ(result.numOfRecord, 1);
+    for (auto it : result.printRecord)
+    {
+        cout << it << endl;
+    }
 
     pEmployeeInfo->name_.last = "MHU";
 
-    pResult = pOperator->schEmployee(false, SelectType::LAST_NAME, *pEmployeeInfo);
-    EXPECT_EQ(pResult->numOfRecord, 0);
+    result = pOperator->schEmployee(false, SelectType::LAST_NAME, *pEmployeeInfo);
+    EXPECT_EQ(result.numOfRecord, 0);
+    for (auto it : result.printRecord)
+    {
+        cout << it << endl;
+    }
 
     delete pEmployeeInfo;
 }
@@ -398,13 +470,21 @@ TEST_F(OperatorTest, schOperatorTestbyCl) {
 
     EmployeeInformation* pEmployeeInfo = new EmployeeInformation(19129568, "SRERLALH", "HMEF", CareerLevel::CL2, 3091, 9521, 1964, 9, 10, CertiLevel::PRO);
 
-    ProcessResult* pResult = pOperator->schEmployee(false, SelectType::CAREER_LEVEL, *pEmployeeInfo);
-    EXPECT_EQ(pResult->numOfRecord, 2);
+    ProcessResult result = pOperator->schEmployee(true, SelectType::CAREER_LEVEL, *pEmployeeInfo);
+    EXPECT_EQ(result.numOfRecord, 2);
+    for (auto it : result.printRecord)
+    {
+        cout << it << endl;
+    }
 
     pEmployeeInfo->careerLevel_ = CareerLevel::CL4;
 
-    pResult = pOperator->schEmployee(false, SelectType::CAREER_LEVEL, *pEmployeeInfo);
-    EXPECT_EQ(pResult->numOfRecord, 4);
+    result = pOperator->schEmployee(false, SelectType::CAREER_LEVEL, *pEmployeeInfo);
+    EXPECT_EQ(result.numOfRecord, 4);
+    for (auto it : result.printRecord)
+    {
+        cout << it << endl;
+    }
 
     delete pEmployeeInfo;
 }
@@ -414,14 +494,22 @@ TEST_F(OperatorTest, schOperatorTestbyPhoneNum) {
 
     EmployeeInformation* pEmployeeInfo = new EmployeeInformation(17112609, "FB", "NTAWR", CareerLevel::CL4, 5645, 6122, 1986, 12, 03, CertiLevel::PRO);
 
-    ProcessResult* pResult = pOperator->schEmployee(false, SelectType::FULL_PHONE_NUMBER, *pEmployeeInfo);
-    EXPECT_EQ(pResult->numOfRecord, 1);
+    ProcessResult result = pOperator->schEmployee(true, SelectType::FULL_PHONE_NUMBER, *pEmployeeInfo);
+    EXPECT_EQ(result.numOfRecord, 1);
+    for (auto it : result.printRecord)
+    {
+        cout << it << endl;
+    }
 
     pEmployeeInfo->phoneNumber_.mid = 1234;
     pEmployeeInfo->phoneNumber_.last = 5678;
 
-    pResult = pOperator->schEmployee(false, SelectType::FULL_PHONE_NUMBER, *pEmployeeInfo);
-    EXPECT_EQ(pResult->numOfRecord, 0);
+    result = pOperator->schEmployee(false, SelectType::FULL_PHONE_NUMBER, *pEmployeeInfo);
+    EXPECT_EQ(result.numOfRecord, 0);
+    for (auto it : result.printRecord)
+    {
+        cout << it << endl;
+    }
 
     delete pEmployeeInfo;
 }
@@ -431,13 +519,21 @@ TEST_F(OperatorTest, schOperatorTestbyMidPhoneNum) {
 
     EmployeeInformation* pEmployeeInfo = new EmployeeInformation(18117906, "TWU", "QSOLT", CareerLevel::CL4, 6672, 7186, 2003, 04, 13, CertiLevel::PRO);
 
-    ProcessResult* pResult = pOperator->schEmployee(false, SelectType::MID_PHONE_NUMBER, *pEmployeeInfo);
-    EXPECT_EQ(pResult->numOfRecord, 1);
+    ProcessResult result = pOperator->schEmployee(true, SelectType::MID_PHONE_NUMBER, *pEmployeeInfo);
+    EXPECT_EQ(result.numOfRecord, 1);
+    for (auto it : result.printRecord)
+    {
+        cout << it << endl;
+    }
 
     pEmployeeInfo->phoneNumber_.mid = 1234;
 
-    pResult = pOperator->schEmployee(false, SelectType::MID_PHONE_NUMBER, *pEmployeeInfo);
-    EXPECT_EQ(pResult->numOfRecord, 0);
+    result = pOperator->schEmployee(false, SelectType::MID_PHONE_NUMBER, *pEmployeeInfo);
+    EXPECT_EQ(result.numOfRecord, 0);
+    for (auto it : result.printRecord)
+    {
+        cout << it << endl;
+    }
 
     delete pEmployeeInfo;
 }
@@ -447,13 +543,21 @@ TEST_F(OperatorTest, schOperatorTestbyLastPhoneNum) {
 
     EmployeeInformation* pEmployeeInfo = new EmployeeInformation(19129568, "SRERLALH", "HMEF", CareerLevel::CL2, 3091, 9521, 1964, 9, 10, CertiLevel::PRO);
 
-    ProcessResult* pResult = pOperator->schEmployee(false, SelectType::LAST_PHONE_NUMBER, *pEmployeeInfo);
-    EXPECT_EQ(pResult->numOfRecord, 1);
+    ProcessResult result = pOperator->schEmployee(true, SelectType::LAST_PHONE_NUMBER, *pEmployeeInfo);
+    EXPECT_EQ(result.numOfRecord, 1);
+    for (auto it : result.printRecord)
+    {
+        cout << it << endl;
+    }
 
     pEmployeeInfo->phoneNumber_.last = 1478;
 
-    pResult = pOperator->schEmployee(false, SelectType::LAST_PHONE_NUMBER, *pEmployeeInfo);
-    EXPECT_EQ(pResult->numOfRecord, 0);
+    result = pOperator->schEmployee(false, SelectType::LAST_PHONE_NUMBER, *pEmployeeInfo);
+    EXPECT_EQ(result.numOfRecord, 0);
+    for (auto it : result.printRecord)
+    {
+        cout << it << endl;
+    }
 
     delete pEmployeeInfo;
 }
@@ -463,13 +567,21 @@ TEST_F(OperatorTest, schOperatorTestbyBirthday) {
 
     EmployeeInformation* pEmployeeInfo = new EmployeeInformation(18117906, "TWU", "QSOLT", CareerLevel::CL4, 6672, 7186, 2003, 04, 13, CertiLevel::PRO);
 
-    ProcessResult* pResult = pOperator->schEmployee(false, SelectType::FULL_BIRTHDAY, *pEmployeeInfo);
-    EXPECT_EQ(pResult->numOfRecord, 1);
+    ProcessResult result = pOperator->schEmployee(true, SelectType::FULL_BIRTHDAY, *pEmployeeInfo);
+    EXPECT_EQ(result.numOfRecord, 1);
+    for (auto it : result.printRecord)
+    {
+        cout << it << endl;
+    }
 
     pEmployeeInfo->birthday_ = { 1999, 10, 01 };
 
-    pResult = pOperator->schEmployee(false, SelectType::FULL_BIRTHDAY, *pEmployeeInfo);
-    EXPECT_EQ(pResult->numOfRecord, 0);
+    result = pOperator->schEmployee(false, SelectType::FULL_BIRTHDAY, *pEmployeeInfo);
+    EXPECT_EQ(result.numOfRecord, 0);
+    for (auto it : result.printRecord)
+    {
+        cout << it << endl;
+    }
 
     delete pEmployeeInfo;
 }
@@ -479,13 +591,21 @@ TEST_F(OperatorTest, schOperatorTestbyYearOfBirthday) {
 
     EmployeeInformation* pEmployeeInfo = new EmployeeInformation(2117175, "SBILHUT", "LDEXRI", CareerLevel::CL4, 2814, 1699, 1995, 07, 04, CertiLevel::ADV);
 
-    ProcessResult* pResult = pOperator->schEmployee(false, SelectType::YEAR_OF_BIRTHDAY, *pEmployeeInfo);
-    EXPECT_EQ(pResult->numOfRecord, 1);
+    ProcessResult result = pOperator->schEmployee(true, SelectType::YEAR_OF_BIRTHDAY, *pEmployeeInfo);
+    EXPECT_EQ(result.numOfRecord, 1);
+    for (auto it : result.printRecord)
+    {
+        cout << it << endl;
+    }
 
     pEmployeeInfo->birthday_.year_ = 2022;
 
-    pResult = pOperator->schEmployee(false, SelectType::YEAR_OF_BIRTHDAY, *pEmployeeInfo);
-    EXPECT_EQ(pResult->numOfRecord, 0);
+    result = pOperator->schEmployee(false, SelectType::YEAR_OF_BIRTHDAY, *pEmployeeInfo);
+    EXPECT_EQ(result.numOfRecord, 0);
+    for (auto it : result.printRecord)
+    {
+        cout << it << endl;
+    }
 
     delete pEmployeeInfo;
 }
@@ -495,13 +615,21 @@ TEST_F(OperatorTest, schOperatorTestbyMonthOfBirthday) {
 
     EmployeeInformation* pEmployeeInfo = new EmployeeInformation(15123099, "VXIHXOTH", "JHOP", CareerLevel::CL3, 3112, 2609, 1977, 12, 11, CertiLevel::ADV);
 
-    ProcessResult* pResult = pOperator->schEmployee(false, SelectType::MONTH_OF_BIRTHDAY, *pEmployeeInfo);
-    EXPECT_EQ(pResult->numOfRecord, 2);
+    ProcessResult result = pOperator->schEmployee(true, SelectType::MONTH_OF_BIRTHDAY, *pEmployeeInfo);
+    EXPECT_EQ(result.numOfRecord, 2);
+    for (auto it : result.printRecord)
+    {
+        cout << it << endl;
+    }
 
     pEmployeeInfo->birthday_.month_ = 01;
 
-    pResult = pOperator->schEmployee(false, SelectType::MONTH_OF_BIRTHDAY, *pEmployeeInfo);
-    EXPECT_EQ(pResult->numOfRecord, 0);
+    result = pOperator->schEmployee(false, SelectType::MONTH_OF_BIRTHDAY, *pEmployeeInfo);
+    EXPECT_EQ(result.numOfRecord, 0);
+    for (auto it : result.printRecord)
+    {
+        cout << it << endl;
+    }
 
     delete pEmployeeInfo;
 }
@@ -511,13 +639,21 @@ TEST_F(OperatorTest, schOperatorTestbyDayOfBirthday) {
 
     EmployeeInformation* pEmployeeInfo = new EmployeeInformation(18115040, "TTETHU", "HBO", CareerLevel::CL3, 4581, 2050, 2008, 07, 18, CertiLevel::ADV);
 
-    ProcessResult* pResult = pOperator->schEmployee(false, SelectType::DAY_OF_BIRTHDAY, *pEmployeeInfo);
-    EXPECT_EQ(pResult->numOfRecord, 3);
+    ProcessResult result = pOperator->schEmployee(true, SelectType::DAY_OF_BIRTHDAY, *pEmployeeInfo);
+    EXPECT_EQ(result.numOfRecord, 3);
+    for (auto it : result.printRecord)
+    {
+        cout << it << endl;
+    }
     
     pEmployeeInfo->setBirthday({ 2022, 3, 7 });
 
-    pResult = pOperator->schEmployee(false, SelectType::DAY_OF_BIRTHDAY, *pEmployeeInfo);
-    EXPECT_EQ(pResult->numOfRecord, 0);
+    result = pOperator->schEmployee(false, SelectType::DAY_OF_BIRTHDAY, *pEmployeeInfo);
+    EXPECT_EQ(result.numOfRecord, 0);
+    for (auto it : result.printRecord)
+    {
+        cout << it << endl;
+    }
 
     delete pEmployeeInfo;
 }
@@ -527,13 +663,21 @@ TEST_F(OperatorTest, schOperatorTestbyCertiLevel) {
 
     EmployeeInformation* pEmployeeInfo = new EmployeeInformation(17112609, "FB", "NTAWR", CareerLevel::CL4, 5645, 6122, 1986, 12, 03, CertiLevel::PRO);
 
-    ProcessResult* pResult = pOperator->schEmployee(false, SelectType::CERTI_LEVEL, *pEmployeeInfo);
-    EXPECT_EQ(pResult->numOfRecord, 7);
+    ProcessResult result = pOperator->schEmployee(true, SelectType::CERTI_LEVEL, *pEmployeeInfo);
+    EXPECT_EQ(result.numOfRecord, 7);
+    for (auto it : result.printRecord)
+    {
+        cout << it << endl;
+    }
 
     pEmployeeInfo->certiLevel_ = CertiLevel::EX;
 
-    pResult = pOperator->schEmployee(false, SelectType::CERTI_LEVEL, *pEmployeeInfo);
-    EXPECT_EQ(pResult->numOfRecord, 0);
+    result = pOperator->schEmployee(false, SelectType::CERTI_LEVEL, *pEmployeeInfo);
+    EXPECT_EQ(result.numOfRecord, 0);
+    for (auto it : result.printRecord)
+    {
+        cout << it << endl;
+    }
 
     delete pEmployeeInfo;
 }
@@ -544,17 +688,29 @@ TEST_F(OperatorTest, modOperatorTestbyName) {
     EmployeeInformation* pEmployeeInfo = new EmployeeInformation(19129568, "SRERLALH", "HMEF", CareerLevel::CL2, 3091, 9521, 1964, 9, 10, CertiLevel::PRO);
     EmployeeInformation* pModEmployeeInfo = new EmployeeInformation(17112609, "Gildong", "Hong", CareerLevel::CL4, 5645, 6122, 1986, 12, 03, CertiLevel::PRO);
 
-    ProcessResult* pResult = pOperator->modEmployee(false, SelectType::CAREER_LEVEL, *pEmployeeInfo, SelectType::FULL_NAME, *pModEmployeeInfo);
-    EXPECT_EQ(pResult->numOfRecord, 2);
+    ProcessResult result = pOperator->modEmployee(true, SelectType::CAREER_LEVEL, *pEmployeeInfo, SelectType::FULL_NAME, *pModEmployeeInfo);
+    EXPECT_EQ(result.numOfRecord, 2);
+    for (auto it : result.printRecord)
+    {
+        cout << it << endl;
+    }
 
-    pResult = pOperator->schEmployee(false, SelectType::FULL_NAME, *pModEmployeeInfo);
-    EXPECT_EQ(pResult->numOfRecord, 2);
+    result = pOperator->schEmployee(false, SelectType::FULL_NAME, *pModEmployeeInfo);
+    EXPECT_EQ(result.numOfRecord, 2);
+    for (auto it : result.printRecord)
+    {
+        cout << it << endl;
+    }
 
     pEmployeeInfo->name_.first = "SRERLALH";
     pEmployeeInfo->name_.last = "HMEF";
 
-    pResult = pOperator->schEmployee(false, SelectType::FULL_NAME, *pEmployeeInfo);
-    EXPECT_EQ(pResult->numOfRecord, 0);
+    result = pOperator->schEmployee(false, SelectType::FULL_NAME, *pEmployeeInfo);
+    EXPECT_EQ(result.numOfRecord, 0);
+    for (auto it : result.printRecord)
+    {
+        cout << it << endl;
+    }
 
     delete pEmployeeInfo;
 }
@@ -578,7 +734,7 @@ TEST_F(OperatorTest, makeRecordTestbyName) {
 
     list.push_back(*pEmployeeInfo);
 
-    vector<string> result = pOperator->getRecordMaker()->makeRecord(true, 1, Command::DEL, list);
+    vector<string> result = pOperator->getRecordMaker()->makeRecord(true, Command::DEL, list);
 
     for (auto str : result)
     {


### PR DESCRIPTION
CMD 처리 시 해당하는 데이터가 없는 경우 "NONE"을 출력하는 케이스가 빠져있어 추가하였습니다.
또한, 기존 Operator 함수에서 지역 변수의 포인터를 리턴하는 치명적인 버그가 있어 리턴형 변경하는 방향으로 수정하였으니 리뷰 부탁드립니다..!