### PR TITLE
fix: add minimun string size checker

### DIFF
--- a/AceAgent/CommandHandler.cpp
+++ b/AceAgent/CommandHandler.cpp
@@ -24,6 +24,7 @@ CommandHandler::Run(string input, string output)
     {
         string commandLine;
         getline(inputFile, commandLine);
+        if (commandLine.size() < MINIMUN_COMMAND_LINE_SIZE) continue;
 
         CommandParser* parser{ new CommandParser() };
         ParseInfo parseInfo;

--- a/AceAgent/CommandHandler.h
+++ b/AceAgent/CommandHandler.h
@@ -6,4 +6,7 @@ class CommandHandler
 {
 public:
 	void Run(string inputFile, string ofstream);
+
+private:
+	static constexpr unsigned int MINIMUN_COMMAND_LINE_SIZE = 5;
 };


### PR DESCRIPTION
- 마지막 공백라인일 들어올 경우 fault가 발생함. 이를방지하고자 읽은
  string이minimun size를 넘지 않는 경우 continue를 실행하도록 변경

Signed-off-by: JaeseungByun <bjs5425@naver.com>